### PR TITLE
Add ability to delete updates from frontend

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -74,6 +74,9 @@ Handlebars.registerHelper("labelFor", function(date) {
 */
 var app = app || {};
 
+// The base of the API
+var API_BASE = "https://lestands-api.herokuapp.com"
+
 $(document).ready(function(){
   var dispatcher = _.clone(Backbone.Events)
   Backbone.history.start();

--- a/app/collections/stands.js
+++ b/app/collections/stands.js
@@ -10,7 +10,7 @@ var app = app || {};
   };
 
   var Stands = Backbone.Collection.extend({
-      url: 'https://lestands-api.herokuapp.com/stands',
+      url: API_BASE + '/stands',
       model: app.Stand,
       initialize: function() {
           this.fetch({reset: true});

--- a/app/collections/updates.js
+++ b/app/collections/updates.js
@@ -1,0 +1,23 @@
+/*global Backbone */
+var app = app || {};
+
+(function () {
+
+  var Updates = Backbone.Collection.extend({
+      model: app.Update,
+      url: function() {
+        return this.baseUrl;
+      }, // 'https://lestands-api.herokuapp.com/stands/:id/updates',
+
+      initialize: function(options) {
+        this.baseUrl = options.standPath + '/updates';
+        this.fetch({reset: true});
+      },
+      comparator: function(m) {
+          // http://stackoverflow.com/questions/9540770/using-underscore-to-sort-a-collection-based-on-date
+          return (new Date(m.get('date'))).getTime();
+      }
+  });
+
+  // app.updates = new Updates();
+})();

--- a/app/collections/updates.js
+++ b/app/collections/updates.js
@@ -3,7 +3,7 @@ var app = app || {};
 
 (function () {
 
-  var Updates = Backbone.Collection.extend({
+  app.Updates = Backbone.Collection.extend({
       model: app.Update,
       url: function() {
         return this.baseUrl;

--- a/app/models/stand.js
+++ b/app/models/stand.js
@@ -8,9 +8,10 @@ var app = app || {};
     updates: null,
     initialize: function () {
     	// Here is where we manage to build the nested url
-	    app.updates = new app.Updates({
+	    var updates = new app.Updates({
 	      standPath: this.url()
 	    });
+	    this.updates = updates;
     }
   });
 

--- a/app/models/stand.js
+++ b/app/models/stand.js
@@ -3,7 +3,6 @@ var app = app || {};
 
 (function () {
   app.Stand = Backbone.Model.extend({
-    // this function returns the number of days since the last update on this model
     urlRoot: 'https://lestands-api.herokuapp.com/stands',
     initialize: function () {
     	// Here is where we manage to build the nested url

--- a/app/models/stand.js
+++ b/app/models/stand.js
@@ -4,8 +4,13 @@ var app = app || {};
 (function () {
   app.Stand = Backbone.Model.extend({
     // this function returns the number of days since the last update on this model
-    urlRoot: 'https://lestands-api.herokuapp.com/stands',
+    // urlRoot: 'https://lestands-api.herokuapp.com/stands',
+    updates: null,
     initialize: function () {
+    	// Here is where we manage to build the nested url
+	    app.updates = new app.Updates({
+	      standPath: this.url()
+	    });
     }
   });
 

--- a/app/models/stand.js
+++ b/app/models/stand.js
@@ -3,7 +3,7 @@ var app = app || {};
 
 (function () {
   app.Stand = Backbone.Model.extend({
-    urlRoot: 'https://lestands-api.herokuapp.com/stands',
+  	urlRoot: API_BASE + '/stands',
     initialize: function () {
     	// Here is where we manage to build the nested url
 	    var updates = new app.Updates({

--- a/app/models/stand.js
+++ b/app/models/stand.js
@@ -4,8 +4,7 @@ var app = app || {};
 (function () {
   app.Stand = Backbone.Model.extend({
     // this function returns the number of days since the last update on this model
-    // urlRoot: 'https://lestands-api.herokuapp.com/stands',
-    updates: null,
+    urlRoot: 'https://lestands-api.herokuapp.com/stands',
     initialize: function () {
     	// Here is where we manage to build the nested url
 	    var updates = new app.Updates({

--- a/app/models/update.js
+++ b/app/models/update.js
@@ -3,19 +3,7 @@ var app = app || {};
 
 (function () {
   app.Update = Backbone.Model.extend({
-    // url: function () {
-    //   // /stands/:stand_id/updates/1
-    //   return this.urlRoot;
-    // },
     urlRoot: 'http://lestands-api.herokuapp.com/stands/1/updates/',
-    // url: function () {
-    //   // /stands/:stand_id/updates/1
-    //   return 'http://lestands-api.herokuapp.com/stands/1/updates/1';
-    // },
-
-    // initialize: function (options) {
-    //   this.urlRoot = options.standPath + '/updates';
-    // }
   });
 
 }());

--- a/app/models/update.js
+++ b/app/models/update.js
@@ -2,7 +2,7 @@
 var app = app || {};
 
 (function () {
-  app.models.Update = Backbone.Model.extend({
+  app.Update = Backbone.Model.extend({
     // url: function () {
     //   // /stands/:stand_id/updates/1
     //   return this.urlRoot;

--- a/app/models/update.js
+++ b/app/models/update.js
@@ -7,6 +7,11 @@ var app = app || {};
     //   // /stands/:stand_id/updates/1
     //   return this.urlRoot;
     // },
+    urlRoot: 'http://lestands-api.herokuapp.com/stands/1/updates/',
+    // url: function () {
+    //   // /stands/:stand_id/updates/1
+    //   return 'http://lestands-api.herokuapp.com/stands/1/updates/1';
+    // },
 
     // initialize: function (options) {
     //   this.urlRoot = options.standPath + '/updates';

--- a/app/models/update.js
+++ b/app/models/update.js
@@ -3,7 +3,9 @@ var app = app || {};
 
 (function () {
   app.Update = Backbone.Model.extend({
-    urlRoot: 'http://lestands-api.herokuapp.com/stands/1/updates/',
+    url: function () {
+      return API_BASE + "/stands/" + this.standID + "/updates/" + this.id;
+    },
   });
 
 }());

--- a/app/models/update.js
+++ b/app/models/update.js
@@ -1,0 +1,16 @@
+/*global Backbone */
+var app = app || {};
+
+(function () {
+  app.models.Update = Backbone.Model.extend({
+    // url: function () {
+    //   // /stands/:stand_id/updates/1
+    //   return this.urlRoot;
+    // },
+
+    // initialize: function (options) {
+    //   this.urlRoot = options.standPath + '/updates';
+    // }
+  });
+
+}());

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -34,6 +34,14 @@ var app = app || {};
               el: $("#main-container"),
               model: singleStand,
             });
+
+            app.updatesView = new app.UpdatesView({
+              el: $("#updates-list"),
+              collection: singleStand.updates,
+            });
+            // options:
+            // 1) one global updates list that we filter
+            // 2) *set this on the fly on each stand view generation* <- for now do this
         }
       })
     },

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -43,7 +43,7 @@ var app = app || {};
             // 1) one global updates list that we filter
             // 2) *set this on the fly on each stand view generation* <- for now do this
         }
-      })
+      });
     },
     addUpdate: function(id) {
       // this fetches the data from the url with the ID as param, and on success creates a new view

--- a/app/views/stands/list.js
+++ b/app/views/stands/list.js
@@ -6,11 +6,6 @@ var app = app || {};
   //view for all stands
   app.StandsView = Backbone.View.extend({
       template: Handlebars.compile( $("#all-stands-template").html() ),
-      events: {
-        // "click .dashboard-link": "homeDude",
-        // "click .create-stand-link": "createStand",
-        // "click .add-update-link": "addUpdateLink",
-      },
       initialize: function(){
               this.listenTo(this.collection, 'reset', this.render);
           },

--- a/app/views/stands/show.js
+++ b/app/views/stands/show.js
@@ -13,25 +13,6 @@ var app = app || {};
       render: function(){
           html = this.template(this.model.attributes);
           this.$el.html(html)
-      },
-      events: {
-        "click a.delete": "deleteUpdate",
-      },
-      deleteUpdate: function(event) {
-        event.preventDefault();
-        var clicked = $(event.target);
-        var updateID = clicked.data('update-id');
-        var standID = clicked.data('stand-id');
-
-        //this console.log is a placeholder for where we need to trigger a json request that deletes an update with a given id
-        console.log("deleteUpdate action triggered. Deleting update with id #" + updateID + ', on stand with id #' + standID);
-
-        // note that we must access the same object as was fetched by /stands/:id->show(),
-        var updates = app.updatesView.collection;
-        var update = updates.findWhere({id: updateID});
-        console.log("remove + destroy update");
-        updates.remove(update);
-        update.destroy();
       }
   });
 

--- a/app/views/stands/show.js
+++ b/app/views/stands/show.js
@@ -26,7 +26,8 @@ var app = app || {};
         //this console.log is a placeholder for where we need to trigger a json request that deletes an update with a given id
         console.log("deleteUpdate action triggered. Deleting update with id #" + updateID + ', on stand with id #' + standID);
 
-        var updates = app.stands.findWhere({id: standID}).updates;
+        // note that we must access the same object as was fetched by /stands/:id->show(),
+        var updates = app.updatesView.collection;
         var update = updates.findWhere({id: updateID});
         console.log("remove + destroy update");
         updates.remove(update);

--- a/app/views/stands/show.js
+++ b/app/views/stands/show.js
@@ -26,11 +26,11 @@ var app = app || {};
         //this console.log is a placeholder for where we need to trigger a json request that deletes an update with a given id
         console.log("deleteUpdate action triggered. Deleting update with id #" + updateID + ', on stand with id #' + standID);
 
-        var stand = _.findWhere(app.stands.models, {id: standID});
-        var update = _.findWhere(stand.updates.models, {id: updateID });
-        stand.updates.remove(update);
-        stand.destroy();
-        // this.sync();
+        var updates = app.stands.findWhere({id: standID}).updates;
+        var update = updates.findWhere({id: updateID});
+        console.log("remove + destroy update");
+        updates.remove(update);
+        update.destroy();
       }
   });
 

--- a/app/views/stands/show.js
+++ b/app/views/stands/show.js
@@ -8,7 +8,6 @@ var app = app || {};
   app.StandView = Backbone.View.extend({
       template: Handlebars.compile( $("#single-stand-template").html() ),
       initialize: function(){
-          this.listenTo(this.model, 'reset', this.render);
           this.render();
       },
       render: function(){
@@ -29,8 +28,9 @@ var app = app || {};
 
         var stand = _.findWhere(app.stands.models, {id: standID});
         var update = _.findWhere(stand.updates.models, {id: updateID });
-        update.destroy();
-
+        stand.updates.remove(update);
+        stand.destroy();
+        // this.sync();
       }
   });
 

--- a/app/views/stands/show.js
+++ b/app/views/stands/show.js
@@ -26,6 +26,11 @@ var app = app || {};
 
         //this console.log is a placeholder for where we need to trigger a json request that deletes an update with a given id
         console.log("deleteUpdate action triggered. Deleting update with id #" + updateID + ', on stand with id #' + standID);
+
+        var stand = _.findWhere(app.stands.models, {id: standID});
+        var update = _.findWhere(stand.updates.models, {id: updateID });
+        update.destroy();
+
       }
   });
 

--- a/app/views/updates/list.js
+++ b/app/views/updates/list.js
@@ -11,6 +11,25 @@ var app = app || {};
               this.listenTo(this.collection, 'remove', this.render);
               this.render();
           },
+      events: {
+        "click a.delete": "deleteUpdate",
+      },
+      deleteUpdate: function(event) {
+        event.preventDefault();
+        var clicked = $(event.target);
+        var updateID = clicked.data('update-id');
+        var standID = clicked.data('stand-id');
+
+        //this console.log is a placeholder for where we need to trigger a json request that deletes an update with a given id
+        console.log("deleteUpdate action triggered. Deleting update with id #" + updateID + ', on stand with id #' + standID);
+
+        // note that we must access the same object as was fetched by /stands/:id->show(),
+        var updates = this.collection;
+        var update = updates.findWhere({id: updateID});
+        console.log("remove + destroy update");
+        updates.remove(update);
+        update.destroy();
+      },
       render: function(){
             // Compile the template using underscore
             view = {

--- a/app/views/updates/list.js
+++ b/app/views/updates/list.js
@@ -18,10 +18,9 @@ var app = app || {};
         event.preventDefault();
         var clicked = $(event.target);
         var updateID = clicked.data('update-id');
-        var standID = clicked.data('stand-id');
 
         //this console.log is a placeholder for where we need to trigger a json request that deletes an update with a given id
-        console.log("deleteUpdate action triggered. Deleting update with id #" + updateID + ', on stand with id #' + standID);
+        console.log("Deleting update with id #" + updateID);
 
         // note that we must access the same object as was fetched by /stands/:id->show(),
         var updates = this.collection;

--- a/app/views/updates/list.js
+++ b/app/views/updates/list.js
@@ -7,7 +7,8 @@ var app = app || {};
   app.UpdatesView = Backbone.View.extend({
       template: Handlebars.compile( $("#all-updates-template").html() ),
       initialize: function(){
-              this.listenTo(this.collection, 'reset', this.render);
+              this.listenTo(this.collection, 'add', this.render);
+              this.listenTo(this.collection, 'remove', this.render);
               this.render();
           },
       render: function(){

--- a/app/views/updates/list.js
+++ b/app/views/updates/list.js
@@ -19,13 +19,11 @@ var app = app || {};
         var clicked = $(event.target);
         var updateID = clicked.data('update-id');
 
-        //this console.log is a placeholder for where we need to trigger a json request that deletes an update with a given id
         console.log("Deleting update with id #" + updateID);
 
         // note that we must access the same object as was fetched by /stands/:id->show(),
         var updates = this.collection;
         var update = updates.findWhere({id: updateID});
-        console.log("remove + destroy update");
         updates.remove(update);
         update.destroy();
       },

--- a/app/views/updates/list.js
+++ b/app/views/updates/list.js
@@ -6,15 +6,15 @@ var app = app || {};
   //view for all updates list
   app.UpdatesView = Backbone.View.extend({
       template: Handlebars.compile( $("#all-updates-template").html() ),
-      initialize: function(){
-              this.listenTo(this.collection, 'add', this.render);
-              this.listenTo(this.collection, 'remove', this.render);
-              this.render();
-          },
+      initialize: function () {
+        this.listenTo(this.collection, 'add', this.render);
+        this.listenTo(this.collection, 'remove', this.render);
+        this.render();
+      },
       events: {
         "click a.delete": "deleteUpdate",
       },
-      deleteUpdate: function(event) {
+      deleteUpdate: function (event) {
         event.preventDefault();
         var clicked = $(event.target);
         var updateID = clicked.data('update-id');
@@ -27,15 +27,15 @@ var app = app || {};
         updates.remove(update);
         update.destroy();
       },
-      render: function(){
-            // Compile the template using underscore
-            view = {
-              updates: _.pluck(this.collection.models, "attributes")
-            };
+      render: function () {
+        // Compile the template using underscore
+        view = {
+          updates: _.pluck(this.collection.models, "attributes")
+        };
 
-            html = this.template(view); //generate HTML from the template
-            this.$el.html(html) //add html to the DOM
-        }
+        html = this.template(view); //generate HTML from the template
+        this.$el.html(html) //add html to the DOM
+      }
   });
 
 })(jQuery);

--- a/app/views/updates/list.js
+++ b/app/views/updates/list.js
@@ -1,0 +1,24 @@
+/*global Backbone */
+var app = app || {};
+
+(function ($) {
+
+  //view for all updates list
+  app.UpdatesView = Backbone.View.extend({
+      template: Handlebars.compile( $("#all-updates-template").html() ),
+      initialize: function(){
+              this.listenTo(this.collection, 'reset', this.render);
+              this.render();
+          },
+      render: function(){
+            // Compile the template using underscore
+            view = {
+              updates: _.pluck(this.collection.models, "attributes")
+            };
+
+            html = this.template(view); //generate HTML from the template
+            this.$el.html(html) //add html to the DOM
+        }
+  });
+
+})(jQuery);

--- a/index.html
+++ b/index.html
@@ -201,18 +201,8 @@
                             </tr>
                           </tr>
                           </thead>
-                          <tbody>
-                          {{#each updates}}
-                            <tr>
-                                <td>{{longDate date}}</td>
-                                <td>{{amountWhenChecked}}</td>
-                                <td class="hidden-xs">{{amountAdded}}</td>
-                                <td class="hidden-xs">{{comments}}</td>
-                                <td class="text-center">
-                                  <a href="#" data-update-id="{{id}}" data-stand-id="{{../id}}" alt="delete an update" class="delete btn btn-danger btn-xs"><i class="fa fa-trash-o"></i> Delete</a>
-                                </td>
-                            </tr>
-                          {{/each}}
+                          <tbody id="updates-list">
+                            <!-- // UPDATES LIST IS INSERTED HERE -->
                           </tbody>
                       </table>
                       </section>
@@ -345,6 +335,26 @@
 
     ********************************************* -->
 
+    <!-- TEMPLATE FOR UPDATES LIST -->
+    <script id="all-updates-template" type="text/template">
+      {{#each updates}}
+      <tr>
+        <td>{{longDate date}}</td>
+        <td>{{amountWhenChecked}}</td>
+        <td class="hidden-xs">{{amountAdded}}</td>
+        <td class="hidden-xs">{{comments}}</td>
+        <td class="text-center">
+          <a href="#" data-update-id="{{id}}" data-stand-id="{{standID}}" alt="delete an update" class="delete btn btn-danger btn-xs"><i class="fa fa-trash-o"></i> Delete</a>
+        </td>
+      </tr>
+      {{/each}}
+    </script>
+
+
+
+    <!-- *********************************************
+
+    ********************************************* -->
 
       <!-- THIS IS THE TEMPLATE FOR ADDING AN UPDATE -->
     <script id="add-update-template" type="text/template">
@@ -507,6 +517,7 @@
     <script src="app/views/stands/list.js"></script>
     <script src="app/views/stands/show.js"></script>
     <script src="app/views/stands/create.js"></script>
+    <script src="app/views/updates/list.js"></script>
     <script src="app/views/updates/create.js"></script>
 		<script src="app/views/app-view.js"></script>
 

--- a/index.html
+++ b/index.html
@@ -495,12 +495,13 @@
     <script src="assets/js/common-scripts.js"></script>
 
     <script src="app/app.js"></script>
+    <script src="app/routers/router.js"></script>
+
     <!--app scripts Models, etc-->
     <script src="app/models/stand.js"></script>
     <script src="app/models/update.js"></script>
 		<script src="app/collections/stands.js"></script>
     <script src="app/collections/updates.js"></script>
-
 
     <!--app Views -->
     <script src="app/views/stands/list.js"></script>
@@ -509,7 +510,6 @@
     <script src="app/views/updates/create.js"></script>
 		<script src="app/views/app-view.js"></script>
 
-    <script src="app/routers/router.js"></script>
 
 
 

--- a/index.html
+++ b/index.html
@@ -494,6 +494,7 @@
     <!--common script for all pages-->
     <script src="assets/js/common-scripts.js"></script>
 
+    <script src="app/app.js"></script>
     <!--app scripts Models, etc-->
     <script src="app/models/stand.js"></script>
     <script src="app/models/update.js"></script>
@@ -511,7 +512,6 @@
     <script src="app/routers/router.js"></script>
 
 
-    <script src="app/app.js"></script>
 
 
   </body>

--- a/index.html
+++ b/index.html
@@ -496,7 +496,10 @@
 
     <!--app scripts Models, etc-->
     <script src="app/models/stand.js"></script>
+    <script src="app/models/update.js"></script>
 		<script src="app/collections/stands.js"></script>
+    <script src="app/collections/updates.js"></script>
+
 
     <!--app Views -->
     <script src="app/views/stands/list.js"></script>

--- a/index.html
+++ b/index.html
@@ -344,7 +344,7 @@
         <td class="hidden-xs">{{amountAdded}}</td>
         <td class="hidden-xs">{{comments}}</td>
         <td class="text-center">
-          <a href="#" data-update-id="{{id}}" data-stand-id="{{standID}}" alt="delete an update" class="delete btn btn-danger btn-xs"><i class="fa fa-trash-o"></i> Delete</a>
+          <a href="#" data-update-id="{{id}}" alt="delete an update" class="delete btn btn-danger btn-xs"><i class="fa fa-trash-o"></i> Delete</a>
         </td>
       </tr>
       {{/each}}


### PR DESCRIPTION
- Fixes #47 

* This adds model, collection, and a (list) view associated with the updates.
* When a Stand is fetched, it fetches its associated updates and stores them as a local variable (`this.updates` from the Stand model perspective).
* When a Stand page is accessed, the router builds the StandView and then builds the UpdatesView list (which is the set of rows that go in the table of updates).
* In the initialization of the UpdatesView we tell the UpdatesView to listen to its collection of updates (which, *importantly*, is the same collection that was fetched by the Stand model which in turn was fetched by the `show()` function in the router; note this is a different object than might be accessed through the app.stands collection, and for event passing to work you have to ensure that you're passing events to the same events that you intend to then listen to later).

