### PR TITLE
Add ability to save new updates from frontend

### DIFF
--- a/app/collections/stands.js
+++ b/app/collections/stands.js
@@ -13,7 +13,7 @@ var app = app || {};
       url: API_BASE + '/stands',
       model: app.Stand,
       initialize: function() {
-          this.fetch({reset: true});
+          this.fetch({reset: true, success: function() { this.fetched = true; /* flag for future checking */ }});
       },
       comparator: function(m) {
           // http://stackoverflow.com/questions/9540770/using-underscore-to-sort-a-collection-based-on-date

--- a/app/models/update.js
+++ b/app/models/update.js
@@ -4,7 +4,12 @@ var app = app || {};
 (function () {
   app.Update = Backbone.Model.extend({
     url: function () {
-      return API_BASE + "/stands/" + this.standID + "/updates/" + this.id;
+      // URL w/o ID for POSTing a new Update that has no ID yet
+      var url = API_BASE + "/stands/" + this.attributes.standID + "/updates";
+      if (typeof this.id !== typeof void 0) { // an existing Update
+        url = url + "/" + this.id;
+      }
+      return url;
     },
   });
 

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -48,6 +48,7 @@ var app = app || {};
     addUpdate: function(id) {
       // this fetches the data from the url with the ID as param, and on success creates a new view
       app.addUpdateView = new app.AddUpdateView({
+        standID: parseInt(id),
         el: $("#main-container")
       });
     },

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -24,7 +24,6 @@ var app = app || {};
       });
     },
     show: function(id) {
-      //right now id is hard-coded as 1 for testing. Change it to id when you're ready for real data.
       var singleStand = new app.Stand ({"id": id});
       //this fetches the data from the url with the ID as param, and on success creates a new view
       singleStand.fetch({

--- a/app/routers/router.js
+++ b/app/routers/router.js
@@ -15,7 +15,6 @@ var app = app || {};
       "update":   "addUpdate",  // #/addupdate
     },
     index: function() {
-      // TodoApp.trigger('fetchTodos', 'completed');
       console.log("index view");
 
       //load dashboard

--- a/app/views/updates/create.js
+++ b/app/views/updates/create.js
@@ -3,6 +3,8 @@ var app = app || {};
 
 (function ($) {
 
+  // documentation on forms and saving new models:
+  // http://dailyjs.com/2013/01/31/backbone-tutorial-10/ see "Editing Tasks"
   //view for adding an update
   app.AddUpdateView = Backbone.View.extend({
       template: Handlebars.compile( $("#add-update-template").html() ),

--- a/app/views/updates/create.js
+++ b/app/views/updates/create.js
@@ -30,6 +30,9 @@ var app = app || {};
   //view for adding an update
   app.AddUpdateView = Backbone.View.extend({
       template: Handlebars.compile( $("#add-update-template").html() ),
+      events: {
+        'submit': 'submit'
+      },
       initialize: function(options){
               this.standID = options.standID || null;
               //this.listenTo(this.model, 'reset', this.render);
@@ -50,8 +53,14 @@ var app = app || {};
               $('.default-date-picker').datepicker();
             }});
         },
+      submit: function(e) {
+            e.preventDefault();
+            var attributes = $('form').serializeObject();
+            var model = new app.Update(attributes);
 
-
+            model.save();
+            return false;
+      },
   });
 
 })(jQuery);

--- a/app/views/updates/create.js
+++ b/app/views/updates/create.js
@@ -6,15 +6,28 @@ var app = app || {};
   //view for adding an update
   app.AddUpdateView = Backbone.View.extend({
       template: Handlebars.compile( $("#add-update-template").html() ),
-      initialize: function(){
+      initialize: function(options){
+              this.standID = options.standID || null;
               //this.listenTo(this.model, 'reset', this.render);
               this.render();
           },
-      render: function(){
-            html = this.template();
-            this.$el.html(html)
-            $('.default-date-picker').datepicker();
-        }
+      render: function () {
+            updateView = this;
+            app.stands.fetch({success: function () {
+              var stand = app.stands.findWhere({id: updateView.standID});
+
+              view = {
+                standID: stand.id,
+                name: stand.get('name')
+              };
+
+              html = updateView.template(view);
+              updateView.$el.html(html);
+              $('.default-date-picker').datepicker();
+            }});
+        },
+
+
   });
 
 })(jQuery);

--- a/app/views/updates/create.js
+++ b/app/views/updates/create.js
@@ -5,6 +5,28 @@ var app = app || {};
 
   // documentation on forms and saving new models:
   // http://dailyjs.com/2013/01/31/backbone-tutorial-10/ see "Editing Tasks"
+
+  // helper function so we can get the form data as an object
+  // from http://stackoverflow.com/a/1186309/1024811
+  // alternatives: https://github.com/hongymagic/jQuery.serializeObject,
+  // https://github.com/powmedia/backbone-forms, https://github.com/marionettejs/backbone.syphon
+  $.fn.serializeObject = function()
+  {
+      var o = {};
+      var a = this.serializeArray();
+      $.each(a, function() {
+          if (o[this.name] !== undefined) {
+              if (!o[this.name].push) {
+                  o[this.name] = [o[this.name]];
+              }
+              o[this.name].push(this.value || '');
+          } else {
+              o[this.name] = this.value || '';
+          }
+      });
+      return o;
+  };
+
   //view for adding an update
   app.AddUpdateView = Backbone.View.extend({
       template: Handlebars.compile( $("#add-update-template").html() ),

--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
                     <div class="row">
                       <div class="col-xs-12">
                         <div class="pull-right">
-                          <a href="#/updates/add" class="btn btn-primary btn-xs"><i class="fa fa-plus"></i> Add update</a>
+                          <a href="#/stands/{{id}}/update" class="btn btn-primary btn-xs"><i class="fa fa-plus"></i> Add update</a>
                           <a href="#/stands/{{id}}/edit" class="btn btn-success btn-xs"><i class="fa fa-pencil"></i> Edit stand</a>
                         </div>
                       </div>

--- a/index.html
+++ b/index.html
@@ -376,12 +376,11 @@
                         <div class="form-group">
                             <label class="control-label col-md-3">Stand name:</label>
                             <div class="col-md-9">
-                              <div id="standsList" style="font-weight:bold;" data-toggle="popover" data-content="Amber's stand near SU" data-trigger="hover">University Ave. &amp; Marshall St.</div>
-                              <input type="hidden" name="deployedStandID" value="33">
+                              <div id="standsList" style="font-weight:bold;" data-toggle="popover" data-content="Amber's stand near SU" data-trigger="hover">{{name}}</div>
+                              <input type="hidden" name="standID" value="{{standID}}">
                                 <span class="help-block"></span>
                             </div>
                         </div>
-
 
                           <div class="form-group">
                               <label class="control-label col-md-3" for="date">Date of update</label>

--- a/index.html
+++ b/index.html
@@ -162,8 +162,8 @@
                     <div class="row">
                       <div class="col-xs-12">
                         <div class="pull-right">
-                          <a href="#/updates/add" class="btn btn-primary btn-xs"><i class="icon-plus"></i> Add update</a>
-                          <a href="#/stands/{{id}}/edit" class="btn btn-success btn-xs"><i class="icon-pencil"></i> Edit stand</a>
+                          <a href="#/updates/add" class="btn btn-primary btn-xs"><i class="fa fa-plus"></i> Add update</a>
+                          <a href="#/stands/{{id}}/edit" class="btn btn-success btn-xs"><i class="fa fa-pencil"></i> Edit stand</a>
                         </div>
                       </div>
                     </div>
@@ -419,7 +419,7 @@
                           <!-- Button -->
                           <div class="form-group">
                             <label class="control-label col-md-4 col-md-offset-5" for="singlebutton"></label>
-                              <button id="singlebutton" name="singlebutton" class="btn btn-lg btn-primary" type="submit"><i class="icon-cloud-upload"></i> Save update</button>
+                              <button id="singlebutton" name="singlebutton" class="btn btn-lg btn-primary" type="submit"><i class="fa fa-cloud-upload"></i> Save update</button>
                           </div>
                       </form>
                   </div>
@@ -478,7 +478,7 @@
                           <!-- Button -->
                           <div class="form-group">
                             <label class="control-label col-md-4 col-md-offset-5" for="singlebutton"></label>
-                              <button id="singlebutton" name="singlebutton" class="btn btn-lg btn-primary" type="submit"><i class="icon-cloud-upload"></i> Save</button>
+                              <button id="singlebutton" name="singlebutton" class="btn btn-lg btn-primary" type="submit"><i class="fa fa-cloud-upload"></i> Save</button>
                           </div>
                       </form>
                   </div>

--- a/index.html
+++ b/index.html
@@ -391,26 +391,26 @@
                           </div>
 
                           <div class="form-group">
-                            <label class="control-label col-md-3" for="before">Quantity before this update</label>
+                            <label class="control-label col-md-3" for="amountWhenChecked">Quantity before this update</label>
                              <div class="col-md-4 col-xs-11">
-                                <input name="amtChecked" id="amtChecked" class="form-control form-control-inline input-medium" placeholder="0" type="text" required="" data-toggle="popover" title="" data-content="How many magazines were in the stand before added more?" data-trigger="hover">
+                                <input name="amountWhenChecked" id="amountWhenChecked" class="form-control form-control-inline input-medium" placeholder="0" type="text" required="" data-toggle="popover" title="" data-content="How many magazines were in the stand before added more?" data-trigger="hover">
                                 <span class="help-block">Count ’em up! This is the number of literature pieces in the stand <em>before</em> you added more.</span>
                              </div>
                           </div>
 
 
                           <div class="form-group">
-                            <label class="control-label col-md-3" for="amtAdded">Amount Added</label>
+                            <label class="control-label col-md-3" for="amountAdded">Amount Added</label>
                             <div class="col-md-4 col-xs-11">
-                              <input name="amtAdded" id="amtAdded" class="form-control form-control-inline input-medium" placeholder="100" type="text" required="" data-toggle="popover" title="" data-content="How many magazines did you add to this stand?" data-trigger="hover">
+                              <input name="amountAdded" id="amountAdded" class="form-control form-control-inline input-medium" placeholder="100" type="text" required="" data-toggle="popover" title="" data-content="How many magazines did you add to this stand?" data-trigger="hover">
                               <span class="help-block">Tip: add magazines in increments of 50 or 100</span>
                             </div>
                           </div>
 
                           <div class="form-group">
-                            <label class="control-label col-md-3" for="description">Comments (optional)</label>
+                            <label class="control-label col-md-3" for="comments">Comments (optional)</label>
                             <div class="col-md-9 col-xs-11">
-                              <textarea rows="3" name="description" id="description" class="form-control form-control-inline input-medium" placeholder="e.g. The sticker is starting to peel off."></textarea>
+                              <textarea rows="3" name="comments" id="comments" class="form-control form-control-inline input-medium" placeholder="e.g. The sticker is starting to peel off."></textarea>
                             </div>
                           </div>
 

--- a/index.html
+++ b/index.html
@@ -485,7 +485,7 @@
               </section>
           </div>
       </div>
-    </script> <!-- END TEMPLATE FOR ADDING AN UPDATE -->
+    </script> <!-- END TEMPLATE FOR ADDING A STAND -->
 
 
 


### PR DESCRIPTION
Getting the new year off to a good start w/ a PR just 3 hours in. ;)

- Fixes #71 

* HOWEVER: After it saves the update, it doesn't do anything with the view. I figured this was a good stopping point, and I'll leave it up to @drewrwilson to determine if we want to fix that before pulling this in. [Update: Drew created #77 to address this issue separately so we can merge this.]

* NOTE: (also) that this pull request should be merged only after #73 since it builds off commits in that branch, and it'll be easier to see the unique aspects of this change once that PR is merged.

Key ideas:
* use `$('form').serializeObject()` to convert a form into an object full of attributes which can be passed into the `Update()` constructor
* create an event for `submit` which calls a `submit()` function.
* `submit()` prevents the default behavior for the form (which was posting to localhost on my dev machine) and instead creates and saves a new update.
