### PR TITLE
Fix stats numbers ("big numbers") when there are no updates

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -37,9 +37,6 @@ var daysSince = function(date) {
   return Math.floor( (today - givenDate) / (1000 * 60 * 60 * 24));
 }
 
-//this assumes we get a valid date string, returns days since a given date
-Handlebars.registerHelper("daysSince", daysSince);
-
 Handlebars.registerHelper("iconFor", function(date) {
   var numDaysSince = daysSince(date);
 
@@ -79,6 +76,24 @@ app.sumAttribute = function(collection, attribute) {
           return memo + model.get(attribute);
         }, 0);
   };
+
+app.lib = {
+  daysSinceInline: function(date) {
+  if (date == -Infinity || date === null) { return "never"; }
+  return daysSince(date) + " days";
+  },
+
+  daysSinceHeader: function(date) {
+    if (date == -Infinity || date === null) { return "n/a"; }
+    return daysSince(date);
+  }
+}
+
+//this assumes we get a valid date string, returns days since a given date
+Handlebars.registerHelper("daysSince", daysSince);
+Handlebars.registerHelper("daysSinceInline", app.lib.daysSinceInline);
+Handlebars.registerHelper("daysSinceHeader", app.lib.daysSinceHeader);
+
 
 // The base of the API
 var API_BASE = "https://lestands-api.herokuapp.com"

--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
                       <i class="fa fa-calendar"></i>
                   </div>
                   <div class="value">
-                      <h1>{{ daysSince lastUpdateDate }}</h1>
+                      <h1>{{ daysSinceHeader lastUpdateDate }}</h1>
                       <p>Days since last checked</p>
                   </div>
               </section>
@@ -232,7 +232,7 @@
                       <i class="fa fa-calendar"></i>
                   </div>
                   <div class="value">
-                      <h1>{{ daysSince lastUpdateDate }}</h1>
+                      <h1>{{ daysSinceHeader lastUpdateDate }}</h1>
                       <p>Days since last checked</p>
                   </div>
               </section>
@@ -278,7 +278,7 @@
                                 <td class=" text-center"><time title="{{lastUpdateDate}}" datetime="{{lastUpdateDate}}" class="label
                                   {{labelFor lastUpdateDate}}">
                                   <i class="fa {{iconFor lastUpdateDate}}"></i>
-                                  {{daysSince lastUpdateDate }} days</time></td>
+                                  {{daysSinceInline lastUpdateDate }}</time></td>
                                 <td><a href="#/stands/{{id}}">{{name}}</a></td>
                                 <td class="hidden-xs">{{description}}</td>
                                 <td class="text-center">


### PR DESCRIPTION
Add a couple more helpers for days-since-update
- Inline: use for inline fields like table columns (includes descriptive text like ‘days’ after the number)
- Header: use for the big summary stats (where the descriptive text is below)

This and https://github.com/drewrwilson/lestandsjs/commit/f066e97902836799b7e640418da4a176d40b06bf together fix #89 